### PR TITLE
Print empty fields for logs if configured that way

### DIFF
--- a/lib/model/flog/flog.dart
+++ b/lib/model/flog/flog.dart
@@ -409,6 +409,7 @@ class FLog {
       methodName = Trace.current().frames[2].member.split(".")[1];
     }
 
+    DateTime now = DateTime.now();
     //check to see if user provides a valid configuration and logs are enabled
     //if not then don't do anything
     if (_isLogsConfigValid()) {
@@ -420,8 +421,8 @@ class FLog {
         logLevel: type,
         dataLogType: dataLogType,
         exception: exception.toString(),
-        timestamp: DateTimeUtils.getCurrentTimestamp(_config),
-        timeInMillis: DateTimeUtils.getCurrentTimeInMillis(),
+        timestamp: DateTimeUtils.getCurrentTimestamp(now, _config),
+        timeInMillis: DateTimeUtils.getCurrentTimeInMillis(now),
         stacktrace: stacktraceString ?? stacktrace.toString(),
       );
 

--- a/lib/model/flog/flog.dart
+++ b/lib/model/flog/flog.dart
@@ -35,11 +35,13 @@ class FLog {
     Exception exception,
     String dataLogType,
     StackTrace stacktrace,
+    String stacktraceString,
   }) async {
     // prevent to write LogLevel.ALL and LogLevel.OFF to db
     if (![LogLevel.OFF, LogLevel.ALL].contains(type)) {
-      _logThis(className, methodName, text, type, exception, dataLogType,
-          stacktrace);
+      _logThis(
+          className, methodName, text, type, exception, dataLogType, stacktrace,
+          stacktraceString: stacktraceString);
     }
   }
 
@@ -57,9 +59,11 @@ class FLog {
     Exception exception,
     String dataLogType,
     StackTrace stacktrace,
+    String stacktraceString,
   }) async {
     _logThis(className, methodName, text, LogLevel.TRACE, exception,
-        dataLogType, stacktrace);
+        dataLogType, stacktrace,
+        stacktraceString: stacktraceString);
   }
 
   /// debug
@@ -76,9 +80,11 @@ class FLog {
     Exception exception,
     String dataLogType,
     StackTrace stacktrace,
+    String stacktraceString,
   }) async {
     _logThis(className, methodName, text, LogLevel.DEBUG, exception,
-        dataLogType, stacktrace);
+        dataLogType, stacktrace,
+        stacktraceString: stacktraceString);
   }
 
   /// info
@@ -95,9 +101,11 @@ class FLog {
     Exception exception,
     String dataLogType,
     StackTrace stacktrace,
+    String stacktraceString,
   }) async {
     _logThis(className, methodName, text, LogLevel.INFO, exception, dataLogType,
-        stacktrace);
+        stacktrace,
+        stacktraceString: stacktraceString);
   }
 
   /// warning
@@ -114,9 +122,11 @@ class FLog {
     Exception exception,
     String dataLogType,
     StackTrace stacktrace,
+    String stacktraceString,
   }) async {
     _logThis(className, methodName, text, LogLevel.WARNING, exception,
-        dataLogType, stacktrace);
+        dataLogType, stacktrace,
+        stacktraceString: stacktraceString);
   }
 
   /// error
@@ -133,9 +143,11 @@ class FLog {
     Exception exception,
     String dataLogType,
     StackTrace stacktrace,
+    String stacktraceString,
   }) async {
     _logThis(className, methodName, text, LogLevel.ERROR, exception,
-        dataLogType, stacktrace);
+        dataLogType, stacktrace,
+        stacktraceString: stacktraceString);
   }
 
   /// severe
@@ -152,9 +164,11 @@ class FLog {
     Exception exception,
     String dataLogType,
     StackTrace stacktrace,
+    String stacktraceString,
   }) async {
     _logThis(className, methodName, text, LogLevel.SEVERE, exception,
-        dataLogType, stacktrace);
+        dataLogType, stacktrace,
+        stacktraceString: stacktraceString);
   }
 
   /// fatal
@@ -171,9 +185,11 @@ class FLog {
     Exception exception,
     String dataLogType,
     StackTrace stacktrace,
+    String stacktraceString,
   }) async {
     _logThis(className, methodName, text, LogLevel.FATAL, exception,
-        dataLogType, stacktrace);
+        dataLogType, stacktrace,
+        stacktraceString: stacktraceString);
   }
 
   /// printLogs
@@ -367,6 +383,8 @@ class FLog {
   /// @param methodName the method name
   /// @param text         the text
   /// @param type         the type
+  /// @param stacktraceString optional stacktrace string. If not null, it will
+  /// override string from stacktrace.toString().
   static void _logThis(
       String className,
       String methodName,
@@ -374,7 +392,8 @@ class FLog {
       LogLevel type,
       Exception exception,
       String dataLogType,
-      StackTrace stacktrace) {
+      StackTrace stacktrace,
+      {String stacktraceString}) {
     assert(text != null);
     assert(type != null);
 
@@ -403,7 +422,7 @@ class FLog {
         exception: exception.toString(),
         timestamp: DateTimeUtils.getCurrentTimestamp(_config),
         timeInMillis: DateTimeUtils.getCurrentTimeInMillis(),
-        stacktrace: stacktrace.toString(),
+        stacktrace: stacktraceString ?? stacktrace.toString(),
       );
 
       //writing it to DB

--- a/lib/model/flog/flog_config.dart
+++ b/lib/model/flog/flog_config.dart
@@ -39,4 +39,5 @@ class LogsConfig {
   var encryptionEnabled = false; //Encryption enabled
   var encryptionKey = ""; //Encryption Key
   var timestampFormat = TimestampFormat.TIME_FORMAT_READABLE; //Timestamp format
+  var printEmpty = false; // If true, print empty field if data is missing. fe. {field1} {field2} {} {null} {field5}
 }

--- a/lib/model/flog/flog_config.dart
+++ b/lib/model/flog/flog_config.dart
@@ -39,5 +39,6 @@ class LogsConfig {
   var encryptionEnabled = false; //Encryption enabled
   var encryptionKey = ""; //Encryption Key
   var timestampFormat = TimestampFormat.TIME_FORMAT_READABLE; //Timestamp format
+  var millisecondsSinceEpochForTimestamp = false;
   var printEmpty = false; // If true, print empty field if data is missing. fe. {field1} {field2} {} {null} {field5}
 }

--- a/lib/utils/datetime/date_time.dart
+++ b/lib/utils/datetime/date_time.dart
@@ -6,21 +6,14 @@ class DateTimeUtils {
   DateTimeUtils._();
 
   //DateTime Methods:-----------------------------------------------------------
-  static int getCurrentTimeInMillis() {
-    final now = DateTime.now();
+  static int getCurrentTimeInMillis(DateTime now) {
     return now.millisecondsSinceEpoch;
   }
 
-  static String getCurrentTimestamp(LogsConfig config) {
-    final now = DateTime.now();
+  static String getCurrentTimestamp(DateTime now, LogsConfig config) {
+    if (config.millisecondsSinceEpochForTimestamp)
+      now.millisecondsSinceEpoch.toString();
     return DateFormat(config.timestampFormat.toString()).format(now);
-  }
-
-  static String getTimeInMillis(LogsConfig config) {
-    final now = DateTime.now();
-    var fiftyDaysFromNow = now.add(new Duration(days: -1));
-    return DateFormat(config.timestampFormat.toString())
-        .format(fiftyDaysFromNow);
   }
 
   static int getStartAndEndTimestamps({@required FilterType type}) {

--- a/lib/utils/datetime/date_time.dart
+++ b/lib/utils/datetime/date_time.dart
@@ -12,7 +12,7 @@ class DateTimeUtils {
 
   static String getCurrentTimestamp(DateTime now, LogsConfig config) {
     if (config.millisecondsSinceEpochForTimestamp)
-      now.millisecondsSinceEpoch.toString();
+      return now.millisecondsSinceEpoch.toString();
     return DateFormat(config.timestampFormat.toString()).format(now);
   }
 

--- a/lib/utils/formatter/formatter.dart
+++ b/lib/utils/formatter/formatter.dart
@@ -6,14 +6,16 @@ class Formatter {
     String output;
 
     if (config.formatType.toString() == FormatType.FORMAT_CURLY.toString()) {
-      output = _formatCurly(log, config.isDevelopmentDebuggingEnabled);
+      output = _formatCurly(
+          log, config.isDevelopmentDebuggingEnabled, config.printEmpty);
     } else if (config.formatType.toString() ==
         FormatType.FORMAT_SQUARE.toString()) {
-      output = _formatSquare(log, config.isDevelopmentDebuggingEnabled);
+      output = _formatSquare(
+          log, config.isDevelopmentDebuggingEnabled, config.printEmpty);
     } else if (config.formatType.toString() ==
         FormatType.FORMAT_CSV.toString()) {
-      output = _formatCsv(
-          log, config.csvDelimiter, config.isDevelopmentDebuggingEnabled);
+      output = _formatCsv(log, config.csvDelimiter,
+          config.isDevelopmentDebuggingEnabled, config.printEmpty);
     } else if (config.formatType.toString() ==
         FormatType.FORMAT_CUSTOM.toString()) {
       output = _formatCustom(
@@ -21,73 +23,96 @@ class Formatter {
           config.customOpeningDivider,
           config.customClosingDivider,
           config.isDevelopmentDebuggingEnabled,
-          config.fieldOrderFormatCustom);
+          config.fieldOrderFormatCustom,
+          config.printEmpty);
     } else {
-      output = _formatCurly(log, config.isDevelopmentDebuggingEnabled);
+      output = _formatCurly(
+          log, config.isDevelopmentDebuggingEnabled, config.printEmpty);
     }
 
     return output + "\n";
   }
 
-  static String _formatCurly(Log log, bool isDevelopmentDebuggingEnabled) {
+  static String _formatCurly(
+      Log log, bool isDevelopmentDebuggingEnabled, bool printEmpty) {
     String output;
 
     if (log != null) {
       output = "{${log.className}} ";
       output += "{${log.methodName}} ";
       output += "{${log.text}} ";
-      output += log.exception != 'null' ? "{${log.exception}} " : "";
+      output += log.exception != 'null'
+          ? "{${log.exception}} "
+          : printEmpty ? "{} " : "";
       output += "{${log.logLevel.toString()}} ";
       output += "{${log.timestamp}} ";
-      output += log.stacktrace != 'null' ? "{${log.stacktrace}} " : "";
+      output += log.stacktrace != 'null'
+          ? "{${log.stacktrace}} "
+          : printEmpty ? "{} " : "";
 
       if (isDevelopmentDebuggingEnabled) {
-        output += !kReleaseMode ? "{${log.dataLogType}} " : "";
-        output += !kReleaseMode ? "{${log.timeInMillis}}" : "";
+        output +=
+            !kReleaseMode ? "{${log.dataLogType}} " : printEmpty ? "{} " : "";
+        output +=
+            !kReleaseMode ? "{${log.timeInMillis}}" : printEmpty ? "{} " : "";
       }
     }
 
     return output;
   }
 
-  static String _formatSquare(Log log, bool isDevelopmentDebuggingEnabled) {
+  static String _formatSquare(
+      Log log, bool isDevelopmentDebuggingEnabled, bool printEmpty) {
     String output;
 
     if (log != null) {
       output = "[${log.className}] ";
       output += "[${log.methodName}] ";
       output += "[${log.text}] ";
-      output += log.exception != 'null' ? "[${log.exception}] " : "";
+      output += log.exception != 'null'
+          ? "[${log.exception}] "
+          : printEmpty ? "[] " : "";
       output += "[${log.logLevel.toString()}] ";
       output += "[${log.timestamp}] ";
-      output += log.stacktrace != 'null' ? "[${log.stacktrace}] " : "";
+      output += log.stacktrace != 'null'
+          ? "[${log.stacktrace}] "
+          : printEmpty ? "[] " : "";
 
       if (isDevelopmentDebuggingEnabled) {
-        output += !kReleaseMode ? "[${log.dataLogType}] " : "";
-        output += !kReleaseMode ? "[${log.timeInMillis}]" : "";
+        output +=
+            !kReleaseMode ? "[${log.dataLogType}] " : printEmpty ? "[] " : "";
+        output +=
+            !kReleaseMode ? "[${log.timeInMillis}]" : printEmpty ? "[] " : "";
       }
     }
 
     return output;
   }
 
-  static String _formatCsv(
-      Log log, String deliminator, bool isDevelopmentDebuggingEnabled) {
+  static String _formatCsv(Log log, String deliminator,
+      bool isDevelopmentDebuggingEnabled, bool printEmpty) {
     String output;
 
     if (log != null) {
       output = "${log.className}$deliminator ";
       output += "${log.methodName}$deliminator ";
       output += "${log.text}$deliminator ";
-      output += log.exception != 'null' ? "${log.exception}$deliminator " : "";
+      output += log.exception != 'null'
+          ? "${log.exception}$deliminator "
+          : printEmpty ? "$deliminator " : "";
       output += "${log.logLevel.toString()}$deliminator ";
       output += "${log.timestamp} ";
-      output +=
-          log.stacktrace != 'null' ? "${log.stacktrace}$deliminator " : "";
+      output += log.stacktrace != 'null'
+          ? "${log.stacktrace}$deliminator "
+          : printEmpty ? "$deliminator " : "";
 
       if (isDevelopmentDebuggingEnabled) {
-        output += !kReleaseMode ? "${log.dataLogType} " : "";
-        output += !kReleaseMode ? "${log.timeInMillis}" : "";
+        output += !kReleaseMode
+            ? "${log.dataLogType} "
+            : printEmpty ? "$deliminator " : "";
+        output += !kReleaseMode
+            ? "${log.timeInMillis}"
+            : printEmpty ? "$deliminator " : "";
       }
     }
 
@@ -95,12 +120,12 @@ class Formatter {
   }
 
   static String _formatCustom(
-    Log log,
-    String openingDivider,
-    String closingDivider,
-    bool isDevelopmentDebuggingEnabled,
-    List<FieldName> fieldOrder,
-  ) {
+      Log log,
+      String openingDivider,
+      String closingDivider,
+      bool isDevelopmentDebuggingEnabled,
+      List<FieldName> fieldOrder,
+      bool printEmpty) {
     String output = "";
 
     if (log != null && fieldOrder.isNotEmpty) {
@@ -117,7 +142,7 @@ class Formatter {
         if (fieldName == FieldName.EXCEPTION) {
           output += log.exception != 'null'
               ? "$openingDivider${log.exception}$closingDivider "
-              : "";
+              : printEmpty ? "$openingDivider$closingDivider " : "";
         }
         if (fieldName == FieldName.LOG_LEVEL) {
           output += "$openingDivider${log.logLevel.toString()}$closingDivider ";
@@ -128,17 +153,17 @@ class Formatter {
         if (fieldName == FieldName.STACKTRACE) {
           output += log.stacktrace != 'null'
               ? "$openingDivider${log.stacktrace}$closingDivider "
-              : "";
+              : printEmpty ? "$openingDivider$closingDivider " : "";
         }
       });
 
       if (isDevelopmentDebuggingEnabled) {
         output += !kReleaseMode
             ? "$openingDivider${log.dataLogType}$closingDivider "
-            : "";
+            : printEmpty ? "$openingDivider$closingDivider " : "";
         output += !kReleaseMode
             ? "$openingDivider${log.timeInMillis}$closingDivider"
-            : "";
+            : printEmpty ? "$openingDivider$closingDivider " : "";
       }
     }
 


### PR DESCRIPTION
This resolves issue described here: https://github.com/zubairehman/Flogs/issues/20
Logs length is not consistent and it could be hard to parse it correctly anywhere else if you need keep fields ordering.