### PR TITLE
Add custom stack trace

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -26,9 +26,11 @@ init() {
 //      DataLogType.NETWORK.toString(),
 //      "Zubair"
 //    ]
+//    ..stackTraceFormatter = CustomFormatter.formatStackTrace
 //    ..timestampFormat = TimestampFormat.TIME_FORMAT_FULL_1;
 
-  /// Configuration example 2
+
+    /// Configuration example 2
 //  LogsConfig config = FLog.getDefaultConfigurations()
 //    ..isDevelopmentDebuggingEnabled = true
 //    ..timestampFormat = TimestampFormat.TIME_FORMAT_FULL_2;
@@ -50,7 +52,17 @@ init() {
     ..customOpeningDivider = "{"
     ..customClosingDivider = "}";
 
+  // typedef String? StackTraceFormatter(StackTrace stackTrace);
+
   FLog.applyConfigurations(config);
+}
+
+class CustomFormatter {
+  static String formatStackTrace(StackTrace stackTrace) {
+    // You can handle the stackTrace here and return your own custom string as stack trace
+    // As an example, the default stack trace is returned
+    return stackTrace.toString();
+  }
 }
 
 class HomePage extends StatefulWidget {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -29,8 +29,7 @@ init() {
 //    ..stackTraceFormatter = CustomFormatter.formatStackTrace
 //    ..timestampFormat = TimestampFormat.TIME_FORMAT_FULL_1;
 
-
-    /// Configuration example 2
+  /// Configuration example 2
 //  LogsConfig config = FLog.getDefaultConfigurations()
 //    ..isDevelopmentDebuggingEnabled = true
 //    ..timestampFormat = TimestampFormat.TIME_FORMAT_FULL_2;
@@ -51,8 +50,6 @@ init() {
     ]
     ..customOpeningDivider = "{"
     ..customClosingDivider = "}";
-
-  // typedef String? StackTraceFormatter(StackTrace stackTrace);
 
   FLog.applyConfigurations(config);
 }

--- a/lib/model/flog/flog.dart
+++ b/lib/model/flog/flog.dart
@@ -4,8 +4,6 @@ import 'package:f_logs/f_logs.dart';
 import 'package:sembast/sembast.dart';
 import 'package:stack_trace/stack_trace.dart';
 
-typedef String StackTraceFormatter(StackTrace stackTrace);
-
 class FLog {
   // flogs data source
   static final _flogDao = FlogDao.instance;
@@ -38,12 +36,11 @@ class FLog {
     dynamic exception,
     String? dataLogType,
     StackTrace? stacktrace,
-    StackTraceFormatter? stackTraceFormatter,
   }) async {
     // prevent to write LogLevel.ALL and LogLevel.OFF to db
     if (![LogLevel.OFF, LogLevel.ALL].contains(type)) {
       _logThis(className, methodName, text, type, exception, dataLogType,
-          stacktrace, stackTraceFormatter);
+          stacktrace);
     }
   }
 
@@ -62,10 +59,9 @@ class FLog {
     dynamic exception,
     String? dataLogType,
     StackTrace? stacktrace,
-    StackTraceFormatter? stackTraceFormatter,
   }) async {
     _logThis(className, methodName, text, LogLevel.TRACE, exception,
-        dataLogType, stacktrace, stackTraceFormatter);
+        dataLogType, stacktrace);
   }
 
   /// debug
@@ -83,10 +79,9 @@ class FLog {
     dynamic exception,
     String? dataLogType,
     StackTrace? stacktrace,
-    StackTraceFormatter? stackTraceFormatter,
   }) async {
     _logThis(className, methodName, text, LogLevel.DEBUG, exception,
-        dataLogType, stacktrace, stackTraceFormatter);
+        dataLogType, stacktrace);
   }
 
   /// info
@@ -103,11 +98,10 @@ class FLog {
     required String text,
     dynamic exception,
     String? dataLogType,
-    StackTrace? stacktrace,
-    StackTraceFormatter? stackTraceFormatter,
+    StackTrace? stacktrace
   }) async {
     _logThis(className, methodName, text, LogLevel.INFO, exception, dataLogType,
-        stacktrace, stackTraceFormatter);
+        stacktrace);
   }
 
   /// warning
@@ -125,10 +119,9 @@ class FLog {
     dynamic exception,
     String? dataLogType,
     StackTrace? stacktrace,
-    StackTraceFormatter? stackTraceFormatter,
   }) async {
     _logThis(className, methodName, text, LogLevel.WARNING, exception,
-        dataLogType, stacktrace, stackTraceFormatter);
+        dataLogType, stacktrace);
   }
 
   /// error
@@ -145,11 +138,9 @@ class FLog {
     required String text,
     dynamic exception,
     String? dataLogType,
-    StackTrace? stacktrace,
-    StackTraceFormatter? stackTraceFormatter,
-  }) async {
+    StackTrace? stacktrace,}) async {
     _logThis(className, methodName, text, LogLevel.ERROR, exception,
-        dataLogType, stacktrace, stackTraceFormatter);
+        dataLogType, stacktrace);
   }
 
   /// severe
@@ -167,10 +158,9 @@ class FLog {
     dynamic exception,
     String? dataLogType,
     StackTrace? stacktrace,
-    StackTraceFormatter? stackTraceFormatter,
   }) async {
     _logThis(className, methodName, text, LogLevel.SEVERE, exception,
-        dataLogType, stacktrace, stackTraceFormatter);
+        dataLogType, stacktrace,);
   }
 
   /// fatal
@@ -188,10 +178,9 @@ class FLog {
     dynamic exception,
     String? dataLogType,
     StackTrace? stacktrace,
-    StackTraceFormatter? stackTraceFormatter,
   }) async {
     _logThis(className, methodName, text, LogLevel.FATAL, exception,
-        dataLogType, stacktrace, stackTraceFormatter);
+        dataLogType, stacktrace);
   }
 
   /// printLogs
@@ -396,8 +385,7 @@ class FLog {
       LogLevel type,
       dynamic exception,
       String? dataLogType,
-      StackTrace? stacktrace,
-      StackTraceFormatter? stackTraceFormatter) {
+      StackTrace? stacktrace) {
     assert(text != null);
     assert(type != null);
 
@@ -415,11 +403,8 @@ class FLog {
 
     // Generate a custom formatted stack trace
     String? formattedStackTrace;
-    if(stackTraceFormatter != null) {
-      if(stacktrace == null) {
-        stacktrace = StackTrace.current;
-      }
-      formattedStackTrace = stackTraceFormatter(stacktrace);
+    if(_config.stackTraceFormatter != null) {
+      formattedStackTrace = _config.stackTraceFormatter!(stacktrace ??  StackTrace.current);
     }
 
     //check to see if user provides a valid configuration and logs are enabled

--- a/lib/model/flog/flog.dart
+++ b/lib/model/flog/flog.dart
@@ -98,7 +98,7 @@ class FLog {
     required String text,
     dynamic exception,
     String? dataLogType,
-    StackTrace? stacktrace
+    StackTrace? stacktrace,
   }) async {
     _logThis(className, methodName, text, LogLevel.INFO, exception, dataLogType,
         stacktrace);
@@ -138,7 +138,8 @@ class FLog {
     required String text,
     dynamic exception,
     String? dataLogType,
-    StackTrace? stacktrace,}) async {
+    StackTrace? stacktrace,
+  }) async {
     _logThis(className, methodName, text, LogLevel.ERROR, exception,
         dataLogType, stacktrace);
   }
@@ -160,7 +161,7 @@ class FLog {
     StackTrace? stacktrace,
   }) async {
     _logThis(className, methodName, text, LogLevel.SEVERE, exception,
-        dataLogType, stacktrace,);
+        dataLogType, stacktrace);
   }
 
   /// fatal

--- a/lib/model/flog/flog_config.dart
+++ b/lib/model/flog/flog_config.dart
@@ -1,5 +1,7 @@
 import 'package:f_logs/f_logs.dart';
 
+typedef String? StackTraceFormatter(StackTrace stackTrace);
+
 class LogsConfig {
   /// print logs in Logcat
   bool isDebuggable = true;
@@ -63,4 +65,7 @@ class LogsConfig {
   /// Timestamp format
   String timestampFormat =
       TimestampFormat.TIME_FORMAT_READABLE; //Timestamp format
+
+  // Configure a custom formatter for the StackTrace
+  StackTraceFormatter? stackTraceFormatter;
 }


### PR DESCRIPTION
This PR adds the option to configure a custom strack trace handler instead of the default `stackTrace.toString()`.
